### PR TITLE
feat: Partial generic tensor operations and FloatType trait

### DIFF
--- a/rust-native-transformer/tensor_core_optimized/Cargo.toml
+++ b/rust-native-transformer/tensor_core_optimized/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2021"
 
 [dependencies]
 libm = "0.2.8"
-half = "2.2.1"
+half = { version = "2.2.1", features = ["num-traits"] }
+num-traits = "0.2.15"
 
 [dev-dependencies]
 rand = "0.8"


### PR DESCRIPTION
This commit introduces the `FloatType` trait and refactors several tensor operations to be generic over `F: FloatType`. This is part of a larger effort to enable runtime precision selection.

Completed Changes:

1.  **Defined `FloatType` Trait:**
    *   Added `FloatType` in `tensor_core_optimized/src/lib.rs` with bounds
        (`Copy`, `Clone`, `Debug`, `PartialEq`, `PartialOrd`, `Send`, `Sync`,
        `'static'`, `num_traits::FloatCore`, `num_traits::NumAssign`).
    *   Defined `ZERO`, `ONE` constants and `from_f32`, `to_f32` methods.

2.  **Implemented `FloatType`:**
    *   Provided implementations for `f32`, `half::f16`, and `half::bf16`.

3.  **Updated `Cargo.toml` for `tensor_core_optimized`:**
    *   Added `num-traits = "0.2.15"`.
    *   Enabled `num-traits` feature for `half = "2.2.1"`.

4.  **Generic `Tensor::zeros` Method:**
    *   Refactored to use `F::ZERO` under `impl<F: FloatType> Tensor<F>`.

5.  **Generic `Tensor::convert` Method:**
    *   Added `convert<T_OUT: FloatType>` to `impl<F: FloatType> Tensor<F>`
        for converting tensor data types via an f32 intermediate.

6.  **Generic `Tensor::scalar_mul` Method:**
    *   Moved to `impl<F: FloatType> Tensor<F>` and updated to use generic type `F`.

7.  **Generic `Tensor::concat` Method:**
    *   Moved to `impl<F: FloatType> Tensor<F>` and updated for generic type `F`.

8.  **Generic `Tensor::matmul` Method:**
    *   Moved to `impl<F: FloatType> Tensor<F>`.
    *   Original f32 logic (SIMD and scalar) extracted to `matmul_f32_compute`.
    *   Generic `matmul` converts inputs (`Tensor<F>`) to `Tensor<f32>`, calls
        `matmul_f32_compute`, and converts the result back to `Tensor<F>`.

9.  **Generic `Tensor::softmax` Method:**
    *   Moved `_flat_index_for_softmax` to `impl<T> Tensor<T>`.
    *   Original f32 logic (SIMD and scalar) extracted to `softmax_f32_compute`.
    *   Generic `softmax` converts input `&Tensor<F>` to `Tensor<f32>`, calls
        `softmax_f32_compute`, and converts the result back to `Tensor<F>`.

Work Remaining (Next Steps):

*   Make `Tensor::layernorm` generic (currently in progress).
*   Make `Tensor::gelu` generic.
*   Refactor `transformer_core.rs` components to be generic over `F: FloatType`.
*   Update `main.rs` for runtime precision selection.
*   Add/Update comprehensive tests for all changes.

This includes the foundational generic infrastructure and refactoring for several key tensor operations.